### PR TITLE
Added gasoline data and calculated percentage change

### DIFF
--- a/Branding.py
+++ b/Branding.py
@@ -493,4 +493,29 @@ def nest_allocation(data):
     return data 
 
 data = nest_allocation(data)
+
+
+## INSTRUMENTS ##
+
+# USE WALDFOGEL-FAN INSTRUMENTS FOR THE PRICE -> CREATE VARIATION IN INCOME OVER TIME BY PROXYING FOR THE CPI USING 
+# THE DEVELOPMENT OF GASOLINE PRICES OVER THE GIVEN TIMEFRAME
+data_gasoline = pd.read_csv(r"C:/Users/behri/OneDrive/Desktop/Master LSE/Essay/Ideas/Pepsi Coke/GASREGW.csv")
+
+week = 146
+for i, idx in enumerate(data_gasoline.index): 
+    data_gasoline.loc[idx, "WEEK"] = week + i
+    
+for idx in range(2, len(data_gasoline["WEEK"])): 
+    data_gasoline.loc[idx, "pct_change"] = (data_gasoline.loc[idx, "GASREGW"] - data_gasoline.loc[idx-1, "GASREGW"]) / (data_gasoline.loc[idx-1, "GASREGW"])
+
+# Assume linear relationship between trends if there is no change in order not to lose the variation across those weeks
+for i in range(1, len(data_gasoline["WEEK"])):
+    if data_gasoline.loc[i,"pct_change"] == 0:
+        data_gasoline.loc[i, "pct_change"] = (data_gasoline.loc[i+1, "pct_change"] + data_gasoline.loc[i-1, "pct_change"]) / 2
+
+data = data.merge(data_gasoline, on = "WEEK", how = "left")
+
+# Create imputed income 
+
+
 #data.to_csv(r"C:/Users/behri/OneDrive/Desktop/Master LSE/Essay/Ideas/Pepsi Coke/final_data.csv")


### PR DESCRIPTION
In order to obtain Waldfogel-Fan instruments, this is a necessary step in order to later impute the income per capita (assumed to be correlated with the price of neighboring stores). I calculate the index using the gasoline price as a proxy for the CPI which does not vary weekly. 